### PR TITLE
Allow empty Child component

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,11 @@
       var childs = this.props.children.filter(Type.isInstance);
 
       if (childs.length > 0) {
-        return childs[0];
+        if (childs[0]._store.props.children) {
+          return childs[0];
+        } else {
+          return null;
+        }
       }
 
       return null;


### PR DESCRIPTION
This allows you to do this 
```javascript
<div id="some-id">
    <If condition={ this.props.age >= this.props.drinkingAge }>
        <Then><span>Have a beer, {this.props.name}!</span></Then>
        <Else />
    </If>
</div>
```

If you only want to conditionally render the ```Then``` and don't have anything for the ```Else```

Otherwise you get an invariant Violation because you don't render a valid React component.  I realize you can do
```javascript
<Else>{null}</Else>
```
now, but I feel this is cleaner