### PR TITLE
Arrays and plain elements (strings, numbers) must be wrapped by span

### DIFF
--- a/src/ReactIf.js
+++ b/src/ReactIf.js
@@ -6,6 +6,11 @@ function render(props) {
     return props.children();
   }
 
+  if (Array.isArray(props.children) 
+      || (props.children && props.children.type == undefined)) {
+    return React.createElement(span, null, props.children);
+  }
+
   return props.children || null;
 }
 


### PR DESCRIPTION
Added a <span> as parent element for array or plain string child. This solves the problem with such cases as:
```
<Then>
  <span>first element</span>
  <span>second element</span>
</Then>
``` 
or 
```
<Then>
  Just text
</Then>
```
P.S. Sorry for my english