### PR TITLE
Migrate to React 15.5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mocha": "^2.5.3",
     "prop-types": ">=15.5.10",
     "react": ">=15.5.0",
-    "react-dom": "^15.1.0",
+    "react-dom": ">=15.5.0",
     "react-test-renderer": "^15.6.1"
   },
   "main": "lib/ReactIf.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "react-if",
   "version": "2.2.0-dev",
-  "dependencies": {},
   "peerDependencies": {
-    "react": ">=0.14.0"
+    "prop-types": ">=15.5.10",
+    "react": ">=15.5.0"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",
@@ -14,9 +14,10 @@
     "enzyme": "^2.3.0",
     "jsdom": "^9.9.1",
     "mocha": "^2.5.3",
-    "react-addons-test-utils": "^15.1.0",
+    "prop-types": ">=15.5.10",
+    "react": ">=15.5.0",
     "react-dom": "^15.1.0",
-    "react": ">=0.14.0"
+    "react-test-renderer": "^15.6.1"
   },
   "main": "lib/ReactIf.js",
   "scripts": {

--- a/src/ReactIf.js
+++ b/src/ReactIf.js
@@ -1,5 +1,6 @@
 
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function render(props) {
   if (typeof props.children === 'function') {


### PR DESCRIPTION
This PR migrates codebase to React 15.5+. Unfortunately also makes it hard to be backward compatible with React <15.5.0.

References:

1. https://github.com/airbnb/enzyme#installation
2. https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html

(Fixes #23)