### PR TITLE
add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,5 +40,6 @@
   "bugs": {
     "url": "https://github.com/romac/react-if/issues"
   },
-  "homepage": "https://github.com/romac/react-if"
+  "homepage": "https://github.com/romac/react-if",
+  "description": "🌗 Render React components conditionally"
 }


### PR DESCRIPTION
otherwise the first part of the readme is picked, which is the badges