### PR TITLE
Fixed a bug of <If /> can't work with react-hot-loader

### DIFF
--- a/src/ReactIf.js
+++ b/src/ReactIf.js
@@ -28,7 +28,7 @@ export function If({ condition, children }) {
     return null;
   }
 
-  return [].concat(children).find(c => c.type !== Else ^ !condition) || null;
+  return [].concat(children).find(c => c.type !== <Else />.type ^ !condition) || null;
 }
 
 const ThenOrElse = PropTypes.oneOfType([


### PR DESCRIPTION
When both use react-if and react-hot-loader.I got a trouble.

```javascript
<If condition={false}>
    <Then>
        then
    </Then>
    <Else>
        else
    </Else>
</If>
```

If I add  `import { hot } from 'react-hot-loader' ` ，the above code will render nothing.
If not, the above code will render `else` normally

Because element type compare error.

[See more detail](https://github.com/gaearon/react-hot-loader/issues/304)