### PR TITLE
Fixed a bug of <If /> can't work with react-hot-loader

### DIFF
--- a/src/ReactIf.js
+++ b/src/ReactIf.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import React from 'react';
 
 function render(props) {
   if (typeof props.children === 'function') {
@@ -28,7 +29,7 @@ export function If({ condition, children }) {
     return null;
   }
 
-  return [].concat(children).find(c => c.type !== Else ^ !condition) || null;
+  return [].concat(children).find(c => c.type !== <Else />.type ^ !condition) || null;
 }
 
 const ThenOrElse = PropTypes.oneOfType([


### PR DESCRIPTION
When I both use react-if and react-hot-loader.I got a trouble.

```javascript
<If condition={false}>
    <Then>
        then
    </Then>
    <Else>
        else
    </Else>
</If>
```

If I add  `import { hot } from 'react-hot-loader' ` ，the above code will render nothing.
If not, the above code will render `else` normally

Because element type compare error.

[See more detail](https://github.com/gaearon/react-hot-loader/issues/304)