### PR TITLE
Allow non-booleans in the `condition` prop as a convenience

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-if'{
   interface IfOptions{
-    condition: (() => boolean) | boolean;
+    condition: (() => any) | any;
   }
 
   /**


### PR DESCRIPTION
For #55 

I think I probably also have to update the `propTypes` to prevent development warnings, but I'm a bit rusty on that, so I will have to figure that out later. Figure I'd open this in the meantime to get comments on the type definitions piece.