### PR TITLE
chore(peer-deps): mark prop-types as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
     "prop-types": ">=15.5.10",
     "react": ">=15.5.0"
   },
+  "peerDependenciesMeta": {
+    "prop-types": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",


### PR DESCRIPTION
prop-types is already a dependency of react and react-dom (and is completely superfluous for TypeScript projects). Marking it as optional gets rid of these warnings in console:
```
[3/4] Linking dependencies...
warning " > react-if@3.4.3" has unmet peer dependency "prop-types@>=15.5.10".
[4/4] Building fresh packages...
```