### PR TITLE
fix: issues with esm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "module": "dist/react-if.esm.js",
   "types": "dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/react-if.esm.js",
+    "import": "./dist/react-if.esm.js",
+    "require": "./dist/index.js",
     "types": "./dist/index.d.ts"
   },
   "sideEffects": false,


### PR DESCRIPTION
`exports.import` was set to a cjs file resulting in an error, when this package was used in esm modules. Its been fixed by swapping the `exports.require` with `exports.import`.