### PR TITLE
Increase fairness in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Take a look at the following presentational component, which contains a commonly
 const Bar = ({ name, age, drinkingAge }) => (
   <div>
     <Header />
-    {age >= drinkingAge ? <span className="ok">Have a beer, {name}!</span> : <span className="not-ok">Sorry, {name}, you are not old enough.</span>}
+    {
+      age >= drinkingAge
+        ? <span className="ok">Have a beer, {name}!</span>
+        : <span className="not-ok">Sorry, {name}, you are not old enough.</span>
+    }
     <Footer />
   </div>
 );


### PR DESCRIPTION
Re-write the first example in a way which would be seen in the wild instead of all on one line. We should make the non `react-if` example as good as it can be so we make a fair comparison.