### PR TITLE
fix: remove deprecated `defaultProps`

### DIFF
--- a/src/Case.tsx
+++ b/src/Case.tsx
@@ -8,7 +8,3 @@ import type { ComponentWithConditionPropsWithFunctionChildren } from './types';
  * @param props The props to pass down to the `<Case />` component
  */
 export const Case: FC<ComponentWithConditionPropsWithFunctionChildren> = (props) => render(props);
-
-Case.defaultProps = {
-  children: null
-};

--- a/src/Default.tsx
+++ b/src/Default.tsx
@@ -7,7 +7,3 @@ import type { FCWithImplicitChildren } from './types';
  * @param props The props to pass down to the `<Default />` component
  */
 export const Default: FCWithImplicitChildren = (props) => render(props);
-
-Default.defaultProps = {
-  children: null
-};

--- a/src/Unless.tsx
+++ b/src/Unless.tsx
@@ -22,7 +22,3 @@ export const Unless: FC<ComponentWithConditionPropsWithFunctionChildren> = ({ co
 
   return !conditionResult && children ? render({ children }) : null;
 };
-
-Unless.defaultProps = {
-  children: null
-};

--- a/src/When.tsx
+++ b/src/When.tsx
@@ -22,7 +22,3 @@ export const When: FC<ComponentWithConditionPropsWithFunctionChildren> = ({ cond
 
   return conditionResult && children ? render({ children }) : null;
 };
-
-When.defaultProps = {
-  children: null
-};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, ReactElement, ReactNode, ValidationMap, WeakValidationMap } from 'react';
+import type { FunctionComponent, PropsWithChildren, ReactNode } from 'react';
 
 /**
  * Type for a value that can properly be parsed by `Boolean(...)`
@@ -57,13 +57,7 @@ export type ComponentWithConditionPropsAsyncSupport = ComponentWithConditionProp
 
 export type FCWithImplicitChildren<P = NonNullObject> = FunctionComponentWithImplicitChildren<P>;
 
-export interface FunctionComponentWithImplicitChildren<P = NonNullObject> {
-  (props: CustomPropsWithChildren<P>, context?: any): ReactElement<any, any> | null;
-  propTypes?: WeakValidationMap<P> | undefined;
-  contextTypes?: ValidationMap<any> | undefined;
-  defaultProps?: Partial<P> | undefined;
-  displayName?: string | undefined;
-}
+export type FunctionComponentWithImplicitChildren<P = NonNullObject> = FunctionComponent<CustomPropsWithChildren<P>>;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NonNullObject = {} & object;


### PR DESCRIPTION
The `defaultProps` are being deprecated by React: https://github.com/reactjs/rfcs/pull/107, https://github.com/facebook/react/pull/16210 

So remove `defaultProps` to avoid warnings from React